### PR TITLE
Refactor embedding utilities into package with main driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,34 @@
 # ordinal-folding-index
 
-This repository accompanies the manuscript on ordinal folding dynamics. The
-`benchmarks/bench1.py` script runs two demonstrations:
+This repository accompanies the manuscript on ordinal folding dynamics.  The code
+is organised as a small library under `library/` and a `main.py` driver script
+that runs all available demonstrations.
 
-1. A fixed-point solver benchmark producing a convergence plot.
-2. An Ordinal Folding Index (OFI) probe for large language models.
+## Library
 
-The OFI benchmark supports OpenAI models and now includes optional support for
-local HuggingFace models such as **GPT-2 Large** and **DeepSeek**. It also
-benchmarks OpenAI's latest **GPT-O3** model. To use the HuggingFace models
-locally, ensure that `transformers` and `torch` are installed.
+```
+library/
+  __init__.py
+  contraction.py   # embedding contraction utility
+  benchmarks.py    # fixed-point and LLM benchmarks
+```
 
-Running `python benchmarks/bench1.py` generates `fixed_point_convergence.png`
-and prints a summary table of OFI scores:
+The `contraction.adjust_embeddings` function implements the contraction
+operator described in the paper for post-processing word embeddings.  The
+`benchmarks` module exposes two entry points:
+
+- `run_fixed_point_benchmark()` – generates the convergence plot of fixed-point
+  solvers.
+- `run_llm_benchmark()` – runs the Ordinal Folding Index (OFI) probe on several
+  language models.  OpenAI models require a valid API key; HuggingFace models
+  require the `transformers` and `torch` packages.
+
+## Usage
+
+Run `python main.py` to execute a short demo of the embedding contraction and
+then run both benchmarks.  The fixed-point benchmark produces the figure
+`fixed_point_convergence.png` and the LLM benchmark prints a summary table of
+OFI scores.  Example output:
 
 ```
 ---------------------------------------------------------
@@ -28,5 +44,8 @@ and prints a summary table of OFI scores:
 ---------------------------------------------------------
 ```
 
-The benchmark uses four factual, three reasoning, and three paradoxical prompts
-to estimate the OFI for each model. 
+The OFI benchmark uses four factual, three reasoning, and three paradoxical
+prompts to estimate the index for each model.  Set the `API_KEY` variable in
+`library/benchmarks.py` or the `OPENAI_API_KEY` environment variable to run with
+the real OpenAI API.  Without a key or without the required libraries, the
+benchmark falls back to mock mode.

--- a/library/benchmarks.py
+++ b/library/benchmarks.py
@@ -1,0 +1,382 @@
+# =============================================================================
+#
+#   Supplemental Material: Python Code (Final Version with Corrected Key Logic)
+#
+#   For the manuscript: "Ultracoarse Equilibria and Ordinal Folding Dynamics
+#   in Operator--Algebraic Infinite Games"
+#
+#   This script contains the implementations for:
+#   1. The analytic benchmark of fixed-point solvers (Section 6.2).
+#   2. The empirical benchmark of the Ordinal Folding Index on LLMs (Section 6.1).
+#
+#   Improvements in this version:
+#   - Corrected the logic for checking the API key to ensure your key is used.
+#   - Your API key has been pre-filled.
+#   - All previous reliability features are maintained.
+#
+# =============================================================================
+
+import numpy as np
+import matplotlib.pyplot as plt
+import os
+import time
+import random
+import re
+
+# --- Configuration ---
+
+# 1. YOUR OPENAI API KEY IS PRE-FILLED BELOW
+#    The script will use this key.
+API_KEY = "sk-proj-.."
+
+# 2. SET TO True TO FORCE MOCK MODE (e.g., for quick testing without API calls)
+FORCE_MOCK_MODE = False
+
+# Attempt to import openai, but don't fail if it's not installed
+try:
+    from openai import OpenAI, APIError
+    OPENAI_AVAILABLE = True
+except ImportError:
+    OPENAI_AVAILABLE = False
+    APIError = Exception # Define a placeholder for error handling
+
+# Attempt to import HuggingFace transformers for local models like GPT-2
+try:
+    from transformers import pipeline
+    import torch
+    HF_AVAILABLE = True
+    HF_PIPELINES = {}
+except ImportError:
+    HF_AVAILABLE = False
+    HF_PIPELINES = {}
+
+# =============================================================================
+#
+#   Part 1: Analytic Benchmark - Fixed-Point Solvers (Section 6.2)
+#
+# =============================================================================
+
+def run_fixed_point_benchmark():
+    """
+    Runs the entire fixed-point benchmark simulation and generates the plot.
+    """
+    print("--- Running Part 1: Fixed-Point Solver Benchmark ---")
+
+    # --- 1. Problem Setup ---
+    N = 200
+    x = np.linspace(0, 1, N)
+    h = x[1] - x[0]
+
+    t_heat = 0.005
+    sigma2 = 4.0 * t_heat
+    heat_kernel = np.exp(-(x[:, None] - x[None, :])**2 / sigma2) / np.sqrt(np.pi * sigma2)
+    A = heat_kernel * h
+
+    def Phi(u):
+        return np.tanh(u)
+
+    forcing_term = (x**2) / 100
+    
+    def T(u):
+        return 0.5 * (A @ Phi(u)) + forcing_term
+
+    # --- 2. Compute High-Accuracy Reference Solution u* ---
+    print("Computing high-accuracy reference solution...")
+    u_star = np.zeros(N)
+    for _ in range(2000):
+        u_star = T(u_star)
+
+    def l2_error(u):
+        return np.linalg.norm(u - u_star) * np.sqrt(h)
+
+    # --- 3. Run Fixed-Point Iterations ---
+    print("Running fixed-point solvers...")
+    max_iter = 50
+    errors = {
+        'Picard': [], 'Mann': [], 'Ishikawa': [], 'Aitken': []
+    }
+
+    # (a) Picard Iteration
+    u = np.zeros(N)
+    for _ in range(max_iter):
+        errors['Picard'].append(l2_error(u))
+        u = T(u)
+
+    # (b) Mann Iteration
+    u = np.zeros(N)
+    for _ in range(max_iter):
+        errors['Mann'].append(l2_error(u))
+        u = 0.5 * u + 0.5 * T(u)
+
+    # (c) Ishikawa Iteration
+    u = np.zeros(N)
+    for _ in range(max_iter):
+        errors['Ishikawa'].append(l2_error(u))
+        v = 0.5 * u + 0.5 * T(u)
+        u = 0.5 * u + 0.5 * T(v)
+
+    # (d) Aitken-Δ² Acceleration
+    u_n_minus_2 = np.zeros(N)
+    errors['Aitken'].append(l2_error(u_n_minus_2))
+    u_n_minus_1 = T(u_n_minus_2)
+    errors['Aitken'].append(l2_error(u_n_minus_1))
+    
+    for _ in range(max_iter - 2):
+        u_n = T(u_n_minus_1)
+        delta1 = u_n_minus_1 - u_n_minus_2
+        delta2 = u_n - 2 * u_n_minus_1 + u_n_minus_2
+        
+        mask = np.abs(delta2) > 1e-14
+        u_accelerated = u_n_minus_2.copy()
+        u_accelerated[mask] = u_n_minus_2[mask] - (delta1[mask]**2) / delta2[mask]
+        
+        errors['Aitken'].append(l2_error(u_accelerated))
+        u_n_minus_2, u_n_minus_1 = u_accelerated, T(u_accelerated)
+
+    # --- 4. Plotting ---
+    print("Generating plot...")
+    plt.style.use('seaborn-v0_8-whitegrid')
+    fig, ax = plt.subplots(figsize=(10, 6))
+    
+    ax.semilogy(errors['Picard'],   label='Picard',           lw=2.5, color='tab:orange')
+    ax.semilogy(errors['Mann'],     label='Mann (α=0.5)',     lw=2.5, color='tab:red')
+    ax.semilogy(errors['Ishikawa'], label='Ishikawa',         lw=2.5, color='tab:green')
+    ax.semilogy(errors['Aitken'],   label='Aitken-Δ² accel.', lw=2.5, color='tab:purple', linestyle='--')
+
+    ax.set_xlabel('Iteration', fontsize=12)
+    ax.set_ylabel(r'$L^2$-error to $u^{\star}$', fontsize=12)
+    ax.set_title('Convergence of Fixed-Point Methods', fontsize=14, pad=10)
+    ax.set_xlim(0, max_iter)
+    ax.set_ylim(1e-12, 10)
+    ax.legend(fontsize=11)
+    
+    plt.tight_layout()
+    plt.savefig('fixed_point_convergence.png')
+    print("Plot saved to fixed_point_convergence.png")
+    plt.show()
+
+
+# =============================================================================
+#
+#   Part 2: Empirical Benchmark - Ordinal Folding Index (OFI) on LLMs (Section 6.1)
+#
+# =============================================================================
+
+PROMPTS = {
+    "Factual": [
+        "What is the capital of France?", "Who wrote '1984'?",
+        "What is the chemical symbol for gold?", "When did the first human land on the moon?",
+    ],
+    "Reasoning": [
+        "A bat and a ball cost $1.10 total. The bat costs $1.00 more than the ball. How much is the ball?",
+        "If all Feps are Zups and some Zups are Bips, are some Feps Bips? Explain.",
+        "There are 3 boxes, all mislabeled: 'Apples', 'Oranges', 'Apples & Oranges'. You pick one fruit from one box. Which box do you pick from to know all correct labels?",
+    ],
+    "Paradoxical": [
+        "This sentence is false. Is the previous sentence true or false?",
+        "The following statement is true. The preceding statement is false. Analyze them.",
+        "A barber shaves all men who do not shave themselves. Who shaves the barber?",
+    ]
+}
+
+def normalize_text(text):
+    """Normalizes text for more reliable comparison."""
+    return re.sub(r'\s+', ' ', text).strip().lower()
+
+def call_api_with_retry(client, model, messages, temperature, max_retries=3):
+    """Calls the modern chat completions API with a retry mechanism."""
+    for attempt in range(max_retries):
+        try:
+            response = client.chat.completions.create(
+                model=model, messages=messages, temperature=temperature, max_tokens=150
+            )
+            return response.choices[0].message.content
+        except APIError as e:
+            print(f"    API Error (attempt {attempt + 1}/{max_retries}): {e}. Retrying...")
+            time.sleep(2 ** attempt) # Exponential backoff
+        except Exception as e:
+            print(f"    An unexpected error occurred: {e}. Aborting prompt.")
+            break
+    return None # Return None if all retries fail
+
+def run_ofi_probe_real(client, model, prompt, max_iter=10, temp_start=0.7, temp_end=0.2):
+    """Performs a real OFI probe using the modern OpenAI API."""
+    history = []
+    messages = [{"role": "user", "content": prompt}]
+    
+    for i in range(1, max_iter + 1):
+        temperature = temp_start - (temp_start - temp_end) * (i / max_iter)
+        
+        response_text = call_api_with_retry(client, model, messages, temperature)
+        if response_text is None:
+            print("    API call failed after multiple retries. Skipping prompt.")
+            return max_iter # Assume non-convergence on failure
+
+        normalized_response = normalize_text(response_text)
+
+        if history and normalized_response == history[-1]:
+            return i
+
+        history.append(normalized_response)
+        messages.append({"role": "assistant", "content": response_text})
+        messages.append({"role": "user", "content": "Please reflect on and refine your previous answer."})
+        
+    return max_iter
+
+def run_ofi_probe_hf(model_name, prompt, max_iter=10, temp_start=0.7, temp_end=0.2):
+    """Performs an OFI probe using a local HuggingFace model."""
+    if not HF_AVAILABLE:
+        print("    transformers library not available. Using mock response.")
+        return max_iter
+
+    if model_name not in HF_PIPELINES:
+        try:
+            generator = pipeline(
+                "text-generation",
+                model=model_name,
+                device=0 if torch.cuda.is_available() else -1,
+                model_kwargs={"torch_dtype": torch.float16 if torch.cuda.is_available() else torch.float32},
+            )
+            generator.tokenizer.pad_token_id = generator.model.config.eos_token_id
+            HF_PIPELINES[model_name] = generator
+        except Exception as e:
+            print(f"    Failed to load model '{model_name}': {e}")
+            return max_iter
+
+    generator = HF_PIPELINES[model_name]
+    history = []
+    text = prompt
+
+    for i in range(1, max_iter + 1):
+        temperature = temp_start - (temp_start - temp_end) * (i / max_iter)
+
+        try:
+            output = generator(
+                text,
+                max_new_tokens=50,
+                do_sample=True,
+                temperature=float(temperature),
+                return_full_text=False,
+            )
+            response_text = output[0]["generated_text"]
+        except Exception as e:
+            print(f"    Local generation failed: {e}")
+            return max_iter
+
+        normalized_response = normalize_text(response_text)
+
+        if history and normalized_response == history[-1]:
+            return i
+
+        history.append(normalized_response)
+        text = response_text + "\nPlease reflect on and refine your previous answer."
+
+    return max_iter
+
+def run_ofi_probe_mock(model_name, category):
+    """A mock version that produces realistic, reproducible random data."""
+    if category == "Factual": return 1
+    if category == "Reasoning":
+        if "Proxy" in model_name: return random.choice([2, 3, 3, 4])
+        return random.choice([1, 2, 2])
+    if category == "Paradoxical":
+        if "Proxy" in model_name: return 10
+        return random.choice([3, 4, 4, 5])
+    return 1
+
+def print_summary_table(results):
+    """Calculates column widths and prints a perfectly formatted table."""
+    header = ["Model", "Factual", "Reasoning", "Paradoxical"]
+    table_data = [header]
+    for model_name, data in results.items():
+        row = [model_name]
+        for cat in header[1:]:
+            mean = data[cat]['mean']
+            std = data[cat]['std']
+            row.append(f"{mean:.1f} ± {std:.1f}")
+        table_data.append(row)
+        
+    col_widths = [max(len(str(item)) for item in col) for col in zip(*table_data)]
+    
+    def print_row(row_items, widths):
+        line = " | ".join(f"{item:<{widths[j]}}" for j, item in enumerate(row_items))
+        print(f" {line} ")
+
+    divider = "-" * (sum(col_widths) + 3 * (len(col_widths) - 1) + 2)
+    
+    print("\n" + divider)
+    print(" " * ((len(divider) - 25) // 2) + "OFI Benchmark Summary Table")
+    print(divider)
+    
+    print_row(table_data[0], col_widths)
+    print(divider)
+    for row in table_data[1:]:
+        print_row(row, col_widths)
+    print(divider)
+
+def run_llm_benchmark():
+    """Runs the full LLM OFI benchmark."""
+    print("\n--- Running Part 2: LLM OFI Benchmark ---")
+    
+    client = None
+    use_mock = True
+    
+    if FORCE_MOCK_MODE:
+        print("Forcing MOCK mode as per configuration.")
+    elif OPENAI_AVAILABLE:
+        # CORRECTED LOGIC: Check if the API_KEY is not the placeholder
+        api_key_to_use = API_KEY if API_KEY and "YOUR_API_KEY_HERE" not in API_KEY else os.environ.get("OPENAI_API_KEY")
+        
+        if api_key_to_use:
+            try:
+                client = OpenAI(api_key=api_key_to_use)
+                client.models.list() 
+                print("\nSUCCESS: OpenAI API key is valid. Running in REAL mode.")
+                use_mock = False
+            except Exception as e:
+                print(f"\nWARNING: API key found but failed to initialize client: {e}")
+                print("Proceeding in MOCK mode.")
+        else:
+            print("\nWARNING: No OpenAI API key found. Running in MOCK mode.")
+            print("To run with the real API, please set the `API_KEY` variable in the script.")
+    else:
+        print("\nWARNING: `openai` library not installed. Running in MOCK mode.")
+
+    models_to_test = {
+        "GPT-3.5 Turbo": ("openai", "gpt-3.5-turbo"),
+        "GPT-O3": ("openai", "gpt-o3"),
+        "GPT-4 (Proxy)": ("openai", "gpt-4"),
+        "GPT-2 Large (HF)": ("hf", "gpt2-large"),
+        "DeepSeek (HF)": ("hf", "deepseek-ai/deepseek-llm-7b-base"),
+    }
+    
+    results = {}
+    for model_name, (provider, model_id) in models_to_test.items():
+        print(f"\nTesting model: {model_name}")
+        results[model_name] = {}
+        for category, prompts in PROMPTS.items():
+            print(f"  Category: {category}")
+            ofi_scores = []
+            for prompt in prompts:
+                if provider == "hf":
+                    if HF_AVAILABLE:
+                        ofi = run_ofi_probe_hf(model_id, prompt)
+                    else:
+                        ofi = run_ofi_probe_mock(model_name, category)
+                else:
+                    if use_mock:
+                        ofi = run_ofi_probe_mock(model_name, category)
+                    else:
+                        ofi = run_ofi_probe_real(client, model_id, prompt)
+                
+                ofi_scores.append(ofi)
+                print(f"    - Prompt OFI: {ofi}")
+            
+            results[model_name][category] = {
+                'mean': np.mean(ofi_scores),
+                'std': np.std(ofi_scores)
+            }
+
+    print_summary_table(results)
+
+    print("="*80)

--- a/library/contraction.py
+++ b/library/contraction.py
@@ -1,0 +1,101 @@
+import numpy as np
+
+"""Utilities for adjusting word embeddings using a contraction operator.
+
+This module implements a simplified version of the fixed-point method
+outlined in the manuscript. It treats the embedding space as a product of
+a hyperbolic component (implemented with the Poincaré ball model) and a
+Euclidean tail. The main entry point is ``adjust_embeddings`` which updates
+selected vectors based on positive and negative anchor sets.
+"""
+
+# ---------------------------------------------------------------------------
+# Basic operations on the Poincaré ball
+# ---------------------------------------------------------------------------
+
+def _mobius_add(x: np.ndarray, y: np.ndarray) -> np.ndarray:
+    xy = np.sum(x * y, axis=-1, keepdims=True)
+    x_sq = np.sum(x * x, axis=-1, keepdims=True)
+    y_sq = np.sum(y * y, axis=-1, keepdims=True)
+    denom = 1 + 2 * xy + x_sq * y_sq
+    return ((1 + 2 * xy + y_sq) * x + (1 - x_sq) * y) / np.clip(denom, 1e-8, None)
+
+def _mobius_scalar_mul(r: float, x: np.ndarray) -> np.ndarray:
+    x_norm = np.linalg.norm(x, axis=-1, keepdims=True)
+    return np.tanh(r * np.arctanh(np.clip(x_norm, 0.0, 0.999))) * x / np.clip(x_norm, 1e-8, None)
+
+def _exp_map(x: np.ndarray, v: np.ndarray) -> np.ndarray:
+    v_norm = np.linalg.norm(v, axis=-1, keepdims=True)
+    second_term = _mobius_scalar_mul(np.tanh(v_norm / 2) / np.clip(v_norm, 1e-8, None), v)
+    return _mobius_add(x, second_term)
+
+def _log_map(x: np.ndarray, y: np.ndarray) -> np.ndarray:
+    diff = _mobius_add(-x, y)
+    diff_norm = np.linalg.norm(diff, axis=-1, keepdims=True)
+    return (2 / np.clip(1 - np.sum(x * x, axis=-1, keepdims=True), 1e-8, None)) * np.arctanh(np.clip(diff_norm, 0.0, 0.999)) * diff / np.clip(diff_norm, 1e-8, None)
+
+# ---------------------------------------------------------------------------
+# Contraction step
+# ---------------------------------------------------------------------------
+
+def _hyperbolic_contraction(x: np.ndarray, m_pos: np.ndarray, m_neg: np.ndarray, alpha: float, beta: float) -> np.ndarray:
+    v_pos = _log_map(x, m_pos)
+    v_neg = _log_map(x, m_neg)
+    inner = float(np.dot(v_neg, v_pos))
+    update = alpha * v_pos - beta * inner * v_neg / np.clip(np.linalg.norm(v_neg), 1e-8, None)
+    return _exp_map(x, update)
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def adjust_embeddings(E: np.ndarray, anchor_sets: dict, d1: int = 10, alpha: float = 0.4, beta: float = 0.1, iters: int = 20) -> np.ndarray:
+    """Applies the contraction operator to selected embeddings.
+
+    Parameters
+    ----------
+    E : ndarray of shape (V, d)
+        Original embeddings.
+    anchor_sets : dict
+        Maps an index ``i`` to a tuple ``(A_plus, A_minus)`` of lists containing
+        positive and negative anchor indices for ``i``.
+    d1 : int, optional
+        Dimension of the hyperbolic component.
+    alpha : float, optional
+        Attraction strength toward the positive centroid. Must satisfy ``0 < alpha < 0.5``.
+    beta : float, optional
+        Repulsion strength from the negative centroid. Use ``0 < beta < alpha``.
+    iters : int, optional
+        Number of contraction iterations to perform.
+
+    Returns
+    -------
+    ndarray
+        The adjusted embeddings of the same shape as ``E``.
+    """
+    d = E.shape[1]
+    assert d1 <= d, "d1 must not exceed embedding dimension"
+    E_new = E.copy()
+
+    for i, (A_pos, A_neg) in anchor_sets.items():
+        if not A_pos or not A_neg:
+            continue
+        x = E_new[i]
+        x_h, x_e = x[:d1], x[d1:]
+        m_pos_h = E_new[A_pos, :d1].mean(axis=0)
+        m_neg_h = E_new[A_neg, :d1].mean(axis=0)
+        m_pos_e = E_new[A_pos, d1:].mean(axis=0)
+        m_neg_e = E_new[A_neg, d1:].mean(axis=0)
+
+        for _ in range(iters):
+            x_h = _hyperbolic_contraction(x_h, m_pos_h, m_neg_h, alpha, beta)
+            v_pos_e = m_pos_e - x_e
+            v_neg_e = m_neg_e - x_e
+            inner_e = float(np.dot(v_neg_e, v_pos_e))
+            x_e = x_e + alpha * v_pos_e - beta * inner_e * v_neg_e / np.clip(np.linalg.norm(v_neg_e), 1e-8, None)
+
+        E_new[i] = np.concatenate([x_h, x_e])
+
+    return E_new
+
+__all__ = ["adjust_embeddings"]

--- a/main.py
+++ b/main.py
@@ -1,0 +1,21 @@
+import numpy as np
+from library.contraction import adjust_embeddings
+from library.benchmarks import run_fixed_point_benchmark, run_llm_benchmark
+
+
+def demo_adjust_embeddings():
+    print("\n--- Demo: adjust_embeddings ---")
+    E = np.random.randn(5, 20)
+    anchor_sets = {0: ([1, 2], [3, 4])}
+    E_adj = adjust_embeddings(E, anchor_sets, d1=5, iters=5)
+    print("Adjusted vector for index 0:", E_adj[0])
+
+
+def main():
+    demo_adjust_embeddings()
+    run_fixed_point_benchmark()
+    run_llm_benchmark()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- turn `embedding_contraction.py` into `library/contraction.py`
- move `benchmarks/bench1.py` logic into `library/benchmarks.py`
- add a `main.py` that demos the contraction and runs benchmarks
- document the new layout and usage in `README.md`

## Testing
- `python -m py_compile library/contraction.py library/benchmarks.py main.py benchmarks/bench1.py`


------
https://chatgpt.com/codex/tasks/task_e_68856d913fc88323b9c2ce2d01eeb7f3