### PR TITLE
Package contraction operator as library

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,26 @@ and prints a summary table of OFI scores:
 The benchmark uses four factual, three reasoning, and three paradoxical prompts
 to estimate the OFI for each model.
 
-The repository also provides `embedding_contraction.py`, which implements the
-contraction operator discussed in the manuscript for post-processing word
-embeddings.  See the module's docstring for usage details.
+## Library usage
+
+The contraction operator discussed in the manuscript is now available as a
+Python library.  Install the package in editable mode:
+
+```bash
+pip install -e .
+```
+
+Then adjust embeddings directly from Python:
+
+```python
+from ordinal_folding import adjust_embeddings
+
+E_new = adjust_embeddings(E, {
+    0: ([1, 2], [3, 4]),                     # uniform weights
+    5: ([6, 7], [8], [0.8, 0.2], [1.0])      # weighted anchors
+})
+```
+
+Anchor sets may optionally include weights, giving individual anchors more or
+less influence.  See the docstring in `ordinal_folding/embedding_contraction.py`
+for full details.

--- a/ordinal_folding/__init__.py
+++ b/ordinal_folding/__init__.py
@@ -1,0 +1,3 @@
+from .embedding_contraction import adjust_embeddings
+
+__all__ = ["adjust_embeddings"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ordinal-folding-index"
+version = "0.1.0"
+description = "Utilities for the ordinal folding index and embedding contraction"
+authors = [{name = "Ordinal Folding Contributors"}]
+license = {text = "MIT"}
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "numpy"
+]
+
+[tool.setuptools]
+packages = ["ordinal_folding"]


### PR DESCRIPTION
## Summary
- Package embedding contraction code as `ordinal_folding` library with packaging metadata
- Support weighted anchor sets in `adjust_embeddings`
- Document installation and usage of the new library

## Testing
- `python -m pip install -e .`
- `python -m py_compile ordinal_folding/embedding_contraction.py ordinal_folding/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68a61780cce883238d3e1be8c8f30dcf